### PR TITLE
Harden package command execution

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -13,6 +13,8 @@ Caching strategy
 
 import json
 import os
+import re
+import shutil
 import subprocess
 import threading
 import time
@@ -59,10 +61,26 @@ def _file_age(path):
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
+_PKG_NAME_RE = re.compile(r"^[A-Za-z0-9@._+-]+$")
+_REPO_NAME_RE = re.compile(r"^[A-Za-z0-9_.+-]+$")
+
+
+def is_safe_package_name(name):
+    return isinstance(name, str) and bool(_PKG_NAME_RE.fullmatch(name))
+
+
+def is_safe_repo_name(name):
+    return isinstance(name, str) and bool(_REPO_NAME_RE.fullmatch(name))
+
+
 def run_command(cmd, timeout=30):
+    if isinstance(cmd, str):
+        return "Internal error: run_command requires an argv list", 1
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         return r.stdout.strip(), r.returncode
+    except FileNotFoundError:
+        return "", 127
     except subprocess.TimeoutExpired:
         return "", 1
     except Exception as e:
@@ -72,9 +90,13 @@ def run_command(cmd, timeout=30):
 def run_command_stream(cmd, on_line, on_done, timeout=180):
     """Run a non-interactive command, streaming output line by line."""
     def worker():
+        if isinstance(cmd, str):
+            GLib.idle_add(on_line, "Internal error: run_command_stream requires an argv list")
+            GLib.idle_add(on_done, 1)
+            return
         try:
             proc = subprocess.Popen(
-                cmd, shell=True,
+                cmd,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
                 text=True, bufsize=1
@@ -90,8 +112,7 @@ def run_command_stream(cmd, on_line, on_done, timeout=180):
 
 
 def _is_demo():
-    _, code = run_command("which pacman 2>/dev/null")
-    return code != 0
+    return shutil.which("pacman") is None
 
 
 # ─── Popular AUR packages to always show in the list ─────────────────────────
@@ -134,7 +155,7 @@ POPULAR_AUR_PACKAGES = [
 def _installed_fingerprint():
     """Fast fingerprint of installed packages using local DB mtime + count."""
     local_db = Path("/var/lib/pacman/local")
-    out, code = run_command("pacman -Q 2>/dev/null")
+    out, code = run_command(["pacman", "-Q"])
     if code != 0:
         return None
     # Combine package count + local db mtime for a fast, reliable fingerprint
@@ -208,7 +229,7 @@ def _build_syncdb(installed_set):
 
     # Fallback: if no .db files found, use pacman -Sl (slower)
     if not pkgs:
-        sl_out, sl_code = run_command("pacman -Sl 2>/dev/null", timeout=60)
+        sl_out, sl_code = run_command(["pacman", "-Sl"], timeout=60)
         if sl_out and sl_code == 0:
             for line in sl_out.splitlines():
                 parts = line.strip().split()
@@ -292,7 +313,7 @@ def get_packages():
             }
 
     # Step 2 — mark AUR/foreign
-    foreign_out, _ = run_command("pacman -Qm 2>/dev/null")
+    foreign_out, _ = run_command(["pacman", "-Qm"])
     for line in (foreign_out or "").splitlines():
         parts = line.strip().split(None, 1)
         if parts and parts[0] in installed_pkgs:
@@ -332,10 +353,12 @@ def invalidate_syncdb_cache():
 # ─── Package info / files ─────────────────────────────────────────────────────
 
 def get_package_info(pkg_name):
-    out, code = run_command(f"pacman -Qi '{pkg_name}' 2>/dev/null")
+    if not is_safe_package_name(pkg_name):
+        return f"Invalid package name: {pkg_name}"
+    out, code = run_command(["pacman", "-Qi", pkg_name])
     if out and code == 0:
         return out
-    out2, code2 = run_command(f"pacman -Si --noconfirm '{pkg_name}' 2>/dev/null")
+    out2, code2 = run_command(["pacman", "-Si", pkg_name])
     if out2 and code2 == 0:
         return out2
     return (f"Name           : {pkg_name}\nVersion        : 1.0.0-1\n"
@@ -349,7 +372,9 @@ def get_package_info(pkg_name):
 
 
 def get_package_files(pkg_name):
-    out, code = run_command(f"pacman -Ql '{pkg_name}' 2>/dev/null")
+    if not is_safe_package_name(pkg_name):
+        return []
+    out, code = run_command(["pacman", "-Ql", pkg_name])
     if out and code == 0:
         return out.splitlines()
     return [f"{pkg_name} /usr/bin/{pkg_name}", f"{pkg_name} /usr/share/man/man1/{pkg_name}.1"]
@@ -358,7 +383,9 @@ def get_package_files(pkg_name):
 # ─── Updates / orphans / sysinfo ─────────────────────────────────────────────
 
 def check_updates():
-    out, code = run_command("checkupdates 2>/dev/null || pacman -Qu 2>/dev/null", timeout=60)
+    out, code = run_command(["checkupdates"], timeout=60)
+    if code != 0:
+        out, code = run_command(["pacman", "-Qu"], timeout=60)
     updates = []
     if out and code == 0:
         for line in out.splitlines():
@@ -369,7 +396,7 @@ def check_updates():
 
 
 def get_orphans():
-    out, _ = run_command("pacman -Qdt 2>/dev/null")
+    out, _ = run_command(["pacman", "-Qdt"])
     orphans = []
     if out:
         for line in out.splitlines():
@@ -387,19 +414,38 @@ def get_orphans():
 
 def get_system_info():
     info = {}
-    out, _ = run_command("uname -r 2>/dev/null"); info["Kernel"] = out or "Unknown"
-    out, _ = run_command("uname -m 2>/dev/null"); info["Architecture"] = out or "x86_64"
-    out, _ = run_command("cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"'")
-    info["OS"] = out or "Arch Linux"
-    out, _ = run_command("pacman --version 2>/dev/null | head -1"); info["Pacman"] = out or "6.0.x"
-    out, _ = run_command("df -h / 2>/dev/null | awk 'NR==2{print $3\"/\"$2\" (\"$5\" used)\"}'")
-    info["Disk (/)"] = out or "N/A"
-    out, _ = run_command("free -h 2>/dev/null | awk 'NR==2{print $3\"/\"$2}'")
-    info["RAM"] = out or "N/A"
-    out, _ = run_command("pacman -Q 2>/dev/null | wc -l"); info["Installed Packages"] = out or "N/A"
-    out, _ = run_command("pacman -Qm 2>/dev/null | wc -l"); info["Foreign (AUR) Packages"] = out or "0"
-    out, _ = run_command("du -sh /var/cache/pacman/pkg 2>/dev/null | cut -f1")
-    info["Package Cache Size"] = out or "N/A"
+    out, _ = run_command(["uname", "-r"]); info["Kernel"] = out or "Unknown"
+    out, _ = run_command(["uname", "-m"]); info["Architecture"] = out or "x86_64"
+    os_name = ""
+    try:
+        with open("/etc/os-release", "r") as f:
+            for line in f:
+                if line.startswith("PRETTY_NAME="):
+                    os_name = line.partition("=")[2].strip().strip('"')
+                    break
+    except Exception:
+        pass
+    info["OS"] = os_name or "Arch Linux"
+    out, _ = run_command(["pacman", "--version"])
+    info["Pacman"] = out.splitlines()[0] if out else "6.0.x"
+    out, _ = run_command(["df", "-h", "/"])
+    if out:
+        lines = out.splitlines()
+        parts = lines[1].split() if len(lines) > 1 else []
+        info["Disk (/)"] = f"{parts[2]}/{parts[1]} ({parts[4]} used)" if len(parts) >= 5 else "N/A"
+    else:
+        info["Disk (/)"] = "N/A"
+    out, _ = run_command(["free", "-h"])
+    if out:
+        mem_line = next((line for line in out.splitlines() if line.startswith("Mem:")), "")
+        parts = mem_line.split()
+        info["RAM"] = f"{parts[2]}/{parts[1]}" if len(parts) >= 3 else "N/A"
+    else:
+        info["RAM"] = "N/A"
+    out, _ = run_command(["pacman", "-Q"]); info["Installed Packages"] = str(len(out.splitlines())) if out else "N/A"
+    out, _ = run_command(["pacman", "-Qm"]); info["Foreign (AUR) Packages"] = str(len(out.splitlines())) if out else "0"
+    out, _ = run_command(["du", "-sh", "/var/cache/pacman/pkg"])
+    info["Package Cache Size"] = out.split()[0] if out else "N/A"
     return info
 
 
@@ -430,7 +476,7 @@ def search_packages_cmd(query):
     packages = []
     seen = set()
 
-    out, code = run_command(f"pacman -Ss '{query}' 2>/dev/null")
+    out, code = run_command(["pacman", "-Ss", query])
     if out and code == 0:
         for p in parse_pacman_ss(out):
             if p["name"] not in seen:
@@ -439,12 +485,11 @@ def search_packages_cmd(query):
 
     aur_helper = None
     for h in ("yay", "paru"):
-        _, c = run_command(f"which {h} 2>/dev/null")
-        if c == 0:
+        if shutil.which(h):
             aur_helper = h
             break
     if aur_helper:
-        aur_out, aur_code = run_command(f"{aur_helper} -Ss --aur '{query}' 2>/dev/null", timeout=30)
+        aur_out, aur_code = run_command([aur_helper, "-Ss", "--aur", query], timeout=30)
         if aur_out and aur_code == 0:
             for p in parse_pacman_ss(aur_out):
                 if p["name"] not in seen:

--- a/dialogs.py
+++ b/dialogs.py
@@ -13,6 +13,8 @@ import pty
 import re as _re
 import select
 import fcntl
+import shlex
+import shutil
 import termios
 import struct
 import threading
@@ -22,7 +24,30 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib, Pango
 
-from backend import run_command, get_orphans, get_system_info
+from backend import (
+    get_orphans, get_system_info, is_safe_package_name, is_safe_repo_name,
+    run_command,
+)
+
+_COUNTRY_RE = _re.compile(r"^[A-Za-z][A-Za-z .'-]{0,63}$")
+
+
+def _display_cmd(cmd):
+    return shlex.join(cmd) if isinstance(cmd, (list, tuple)) else cmd
+
+
+def _editor_cmd(path):
+    allowed = {"nano", "vim", "vi", "micro", "emacs"}
+    raw = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "nano"
+    try:
+        parts = shlex.split(raw)
+    except ValueError:
+        parts = ["nano"]
+    editor = parts[0] if parts else "nano"
+    if os.path.basename(editor) not in allowed:
+        editor = "nano"
+        parts = [editor]
+    return ["sudo", "-S", *parts, path]
 
 
 # ─── Terminal dialog ──────────────────────────────────────────────────────────
@@ -63,7 +88,7 @@ def run_terminal_dialog(parent, cmd, title, on_success=None, on_done_extra=None)
     hdr.pack_start(cancel_btn)
     tv.add_top_bar(hdr)
 
-    cmd_lbl = Gtk.Label(label=f"$ {cmd}")
+    cmd_lbl = Gtk.Label(label=f"$ {_display_cmd(cmd)}")
     cmd_lbl.add_css_class("caption")
     cmd_lbl.add_css_class("dim-label")
     cmd_lbl.set_halign(Gtk.Align.START)
@@ -221,23 +246,18 @@ def run_terminal_dialog(parent, cmd, title, on_success=None, on_done_extra=None)
         except Exception:
             pass
 
-        safe_title = title.replace("'", "")
-        wrapped = (
-            f"printf '\\033[1m>>> {safe_title}\\033[0m\\n'; "
-            f"echo; "
-            f"{cmd}; "
-            f"_ec=$?; "
-            f"exit $_ec"
-        )
-
         env = dict(os.environ)
         env['TERM'] = 'xterm-256color'
         env.pop('SUDO_ASKPASS', None)
 
         try:
             import subprocess
+            GLib.idle_add(append_output, f">>> {title}\n\n")
+            if isinstance(cmd, str):
+                raise TypeError("terminal commands must be argv lists")
+            popen_cmd = cmd
             proc = subprocess.Popen(
-                ["sh", "-c", wrapped],
+                popen_cmd,
                 stdin=slave_fd, stdout=slave_fd, stderr=slave_fd,
                 close_fds=True, preexec_fn=os.setsid, env=env,
             )
@@ -324,7 +344,7 @@ def show_repo_manager(parent, run_terminal_fn):
     edit_btn.add_css_class("suggested-action")
     edit_btn.connect("clicked", lambda *_: (
         dialog.close(),
-        run_terminal_fn("sudo -S ${VISUAL:-${EDITOR:-nano}} /etc/pacman.conf", "Edit pacman.conf")
+        run_terminal_fn(_editor_cmd("/etc/pacman.conf"), "Edit pacman.conf")
     ))
     hdr.pack_end(edit_btn)
 
@@ -342,8 +362,14 @@ def show_repo_manager(parent, run_terminal_fn):
     repos_group.set_title("Active Repositories")
     repos_group.set_description("Repositories currently enabled in /etc/pacman.conf")
 
-    out, code = run_command("pacman -Sl 2>/dev/null | awk '{print $1}' | sort -u")
-    repos = [r for r in out.splitlines() if r.strip()] if (out and code == 0) else ["core", "extra", "multilib"]
+    out, code = run_command(["pacman", "-Sl"])
+    repo_counts = {}
+    if out and code == 0:
+        for line in out.splitlines():
+            parts = line.split()
+            if parts and is_safe_repo_name(parts[0]):
+                repo_counts[parts[0]] = repo_counts.get(parts[0], 0) + 1
+    repos = sorted(repo_counts) if repo_counts else ["core", "extra", "multilib"]
 
     for repo in repos:
         row = Adw.ActionRow()
@@ -351,9 +377,9 @@ def show_repo_manager(parent, run_terminal_fn):
         icon = Gtk.Image.new_from_icon_name("folder-symbolic")
         icon.add_css_class("dim-label")
         row.add_prefix(icon)
-        pkg_out, _ = run_command(f"pacman -Sl {repo} 2>/dev/null | wc -l")
-        if pkg_out and pkg_out.strip().isdigit():
-            count_lbl = Gtk.Label(label=f"{pkg_out.strip()} pkgs")
+        pkg_count = repo_counts.get(repo)
+        if pkg_count is not None:
+            count_lbl = Gtk.Label(label=f"{pkg_count} pkgs")
             count_lbl.add_css_class("caption"); count_lbl.add_css_class("dim-label")
             row.add_suffix(count_lbl)
         repos_group.add(row)
@@ -368,7 +394,11 @@ def show_repo_manager(parent, run_terminal_fn):
     scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
     scroll.add_css_class("card")
 
-    conf_out, _ = run_command("cat /etc/pacman.conf 2>/dev/null")
+    try:
+        with open("/etc/pacman.conf", "r") as f:
+            conf_out = f.read()
+    except Exception:
+        conf_out = ""
     buf = Gtk.TextBuffer()
     buf.set_text(conf_out or "# /etc/pacman.conf not found or not readable")
     conf_view = Gtk.TextView(buffer=buf)
@@ -413,8 +443,7 @@ def show_mirror_rater(parent, run_terminal_fn):
     outer.set_margin_top(16);   outer.set_margin_bottom(24)
     outer.set_margin_start(16); outer.set_margin_end(16)
 
-    _, code = run_command("which rate-mirrors 2>/dev/null")
-    has_rate_mirrors = (code == 0)
+    has_rate_mirrors = shutil.which("rate-mirrors") is not None
 
     if has_rate_mirrors:
         options_group = Adw.PreferencesGroup()
@@ -508,19 +537,26 @@ def show_mirror_rater(parent, run_terminal_fn):
 
             global_flags = []
             if https_only:
-                global_flags.append("--protocol=https")
+                global_flags.append(shlex.quote("--protocol=https"))
             if top_n > 0:
-                global_flags.append(f"--top-mirrors={top_n}")
+                global_flags.append(shlex.quote(f"--top-mirrors={top_n}"))
             if countries_raw:
                 first = countries_raw.split(",")[0].strip()
-                global_flags.append(f"--entry-country={first!r}")
+                if not _COUNTRY_RE.fullmatch(first):
+                    country_entry.add_css_class("error")
+                    return
+                country_entry.remove_css_class("error")
+                global_flags.append(shlex.quote(f"--entry-country={first}"))
 
-            sub_flags = [f"--sort-mirrors-by={sort_key}", f"--max-delay={max_delay}"]
+            sub_flags = [
+                shlex.quote(f"--sort-mirrors-by={sort_key}"),
+                shlex.quote(f"--max-delay={max_delay}"),
+            ]
             gf = " ".join(global_flags)
             sf = " ".join(sub_flags)
 
             if backup:
-                cmd = (
+                script = (
                     f'sudo -S -v && '
                     f'TMPFILE="$(mktemp)" && '
                     f'rate-mirrors {gf} --save="$TMPFILE" arch {sf} '
@@ -529,12 +565,13 @@ def show_mirror_rater(parent, run_terminal_fn):
                     f'&& echo "Done — backup saved to /etc/pacman.d/mirrorlist-backup"'
                 )
             else:
-                cmd = (
+                script = (
                     f'sudo -S -v && '
                     f'rate-mirrors {gf} arch {sf} '
                     f'| sudo tee /etc/pacman.d/mirrorlist > /dev/null '
                     f'&& echo "Done — /etc/pacman.d/mirrorlist updated"'
                 )
+            cmd = ["sh", "-c", script]
 
             dialog.close()
             run_terminal_fn(cmd, "Rate Mirrors")
@@ -559,7 +596,12 @@ def show_mirror_rater(parent, run_terminal_fn):
             if top_n > 0:  gflags.append(f"--top-mirrors={top_n}")
             if countries_raw:
                 first = countries_raw.split(",")[0].strip()
-                gflags.append(f"--entry-country={first!r}")
+                if _COUNTRY_RE.fullmatch(first):
+                    country_entry.remove_css_class("error")
+                    gflags.append(f"--entry-country={first}")
+                else:
+                    country_entry.add_css_class("error")
+                    gflags.append("--entry-country=<invalid>")
             sflags = [f"--sort-mirrors-by={sort_key}", f"--max-delay={max_delay}"]
             preview_lbl.set_label(
                 f"rate-mirrors {' '.join(gflags)} arch {' '.join(sflags)} | sudo tee /etc/pacman.d/mirrorlist"
@@ -586,7 +628,7 @@ def show_mirror_rater(parent, run_terminal_fn):
         install_btn.set_halign(Gtk.Align.CENTER)
         install_btn.connect("clicked", lambda *_: (
             dialog.close(),
-            run_terminal_fn("sudo -S pacman -S --noconfirm rate-mirrors", "Install rate-mirrors")
+            run_terminal_fn(["sudo", "-S", "pacman", "-S", "rate-mirrors"], "Install rate-mirrors")
         ))
         status.set_child(install_btn)
         outer.append(status)
@@ -660,9 +702,12 @@ def show_orphan_finder(parent, run_terminal_fn):
             rm_btn.add_css_class("destructive-action"); rm_btn.add_css_class("flat")
             rm_btn.set_valign(Gtk.Align.CENTER)
             name = o["name"]
+            if not is_safe_package_name(name):
+                rm_btn.set_sensitive(False)
             rm_btn.connect("clicked", lambda *_, n=name: (
                 dialog.close(),
-                run_terminal_fn(f"sudo -S pacman -R --noconfirm {n}", f"Remove {n}")
+                run_terminal_fn(["sudo", "-S", "pacman", "-R", n], f"Remove {n}")
+                if is_safe_package_name(n) else None
             ))
             row.add_suffix(rm_btn)
             listbox.append(row)
@@ -673,12 +718,13 @@ def show_orphan_finder(parent, run_terminal_fn):
         btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         btn_box.set_halign(Gtk.Align.CENTER)
         btn_box.set_margin_top(12); btn_box.set_margin_bottom(16)
-        names = " ".join(o["name"] for o in orphans)
+        names = [o["name"] for o in orphans if is_safe_package_name(o["name"])]
         remove_all_btn = Gtk.Button(label=f"Remove All {len(orphans)} Orphans")
         remove_all_btn.add_css_class("destructive-action")
+        remove_all_btn.set_sensitive(len(names) == len(orphans))
         remove_all_btn.connect("clicked", lambda *_: (
             dialog.close(),
-            run_terminal_fn(f"sudo -S pacman -Rns --noconfirm {names}", "Remove All Orphans")
+            run_terminal_fn(["sudo", "-S", "pacman", "-Rns", *names], "Remove All Orphans")
         ))
         btn_box.append(remove_all_btn)
         outer.append(btn_box)

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ done
 
 if [[ ${#MISSING_PKGS[@]} -gt 0 ]]; then
     warn "Installing missing packages: ${MISSING_PKGS[*]}"
-    pacman -Sy --noconfirm --needed "${MISSING_PKGS[@]}" || die "Failed to install dependencies."
+    pacman -Sy --needed "${MISSING_PKGS[@]}" || die "Failed to install dependencies."
     success "Dependencies installed."
 else
     success "All dependencies satisfied."

--- a/window.py
+++ b/window.py
@@ -5,6 +5,7 @@ filtering, and all action handlers.
 """
 
 import threading
+import shutil
 
 import gi
 gi.require_version('Gtk', '4.0')
@@ -15,6 +16,7 @@ from backend import (
     get_packages, get_package_info, get_package_files,
     check_updates, search_packages_cmd, run_command,
     invalidate_cache, invalidate_syncdb_cache,
+    is_safe_package_name,
 )
 from models import PackageItem, PackageRow, NavRow, REPO_BADGE_CLASS, pkg_icon
 from dialogs import (
@@ -1504,6 +1506,15 @@ class pachubWindow(Adw.ApplicationWindow):
             self._load_packages()
         run_terminal_dialog(self, cmd, title, on_success=on_success, on_done_extra=_on_done)
 
+    def _show_toast(self, message):
+        toast = Adw.Toast()
+        toast.set_title(message)
+        toast.set_timeout(4)
+        try:
+            self._toast_overlay.add_toast(toast)
+        except AttributeError:
+            pass
+
     def _on_refresh(self, *_):
         self._all_packages = []
         self._updates = None
@@ -1518,7 +1529,7 @@ class pachubWindow(Adw.ApplicationWindow):
 
     def _on_sync_db(self, *_):
         invalidate_syncdb_cache()
-        self._run_terminal("sudo -S pacman -Sy --noconfirm", "Sync Databases")
+        self._run_terminal(["sudo", "-S", "pacman", "-Sy"], "Sync Databases")
 
     def _on_upgrade(self, *_):
         def _after():
@@ -1526,16 +1537,16 @@ class pachubWindow(Adw.ApplicationWindow):
             self._updates = []
             self.stat_updates._num.set_label("0")
             self._nav_rows["updates"].set_count(0)
-        self._run_terminal("sudo -S pacman -Syu --noconfirm", "System Upgrade", on_success=_after)
+        self._run_terminal(["sudo", "-S", "pacman", "-Syu"], "System Upgrade", on_success=_after)
 
     def _on_clean_cache(self, *_):
         self._run_terminal(
-            "sudo -S -v && { paccache -rk2 2>/dev/null || sudo pacman -Sc --noconfirm; }",
+            ["sh", "-c", "sudo -S -v && { paccache -rk2 2>/dev/null || sudo pacman -Sc; }"],
             "Clean Cache")
 
     def _on_check_updates(self, *_):
         self._run_terminal(
-            "checkupdates 2>/dev/null || pacman -Qu 2>/dev/null || echo 'No updates available'",
+            ["sh", "-c", "checkupdates 2>/dev/null || pacman -Qu 2>/dev/null || echo 'No updates available'"],
             "Check for Updates")
 
     def _on_manage_repos(self, *_):
@@ -1554,12 +1565,15 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
+        if not is_safe_package_name(pkg.pkg_name):
+            self._show_toast(f"Invalid package name: {pkg.pkg_name}")
+            return
         if pkg.pkg_foreign:
             helper = self._get_aur_helper()
-            cmd = f"{helper} -S --noconfirm {pkg.pkg_name}" if helper \
-                  else f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = [helper, "-S", pkg.pkg_name] if helper \
+                  else ["sudo", "-S", "pacman", "-Sy", pkg.pkg_name]
         else:
-            cmd = f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = ["sudo", "-S", "pacman", "-Sy", pkg.pkg_name]
         self._run_terminal(cmd, f"Install {pkg.pkg_name}",
                            on_success=self._refresh_selected_pkg)
 
@@ -1567,6 +1581,9 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
+        if not is_safe_package_name(pkg.pkg_name):
+            self._show_toast(f"Invalid package name: {pkg.pkg_name}")
+            return
         d = Adw.AlertDialog()
         d.set_heading(f"Remove {pkg.pkg_name}?")
         d.set_body(f"This will remove {pkg.pkg_name} ({pkg.pkg_version}) from your system.")
@@ -1576,7 +1593,7 @@ class pachubWindow(Adw.ApplicationWindow):
         def on_resp(dlg, resp):
             if resp == "remove":
                 self._run_terminal(
-                    f"sudo -S pacman -R --noconfirm {pkg.pkg_name}",
+                    ["sudo", "-S", "pacman", "-R", pkg.pkg_name],
                     f"Remove {pkg.pkg_name}",
                     on_success=self._refresh_selected_pkg)
         d.connect("response", on_resp)
@@ -1586,12 +1603,15 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
+        if not is_safe_package_name(pkg.pkg_name):
+            self._show_toast(f"Invalid package name: {pkg.pkg_name}")
+            return
         if pkg.pkg_foreign:
             helper = self._get_aur_helper()
-            cmd = f"{helper} -S --noconfirm {pkg.pkg_name}" if helper \
-                  else f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = [helper, "-S", pkg.pkg_name] if helper \
+                  else ["sudo", "-S", "pacman", "-Sy", pkg.pkg_name]
         else:
-            cmd = f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = ["sudo", "-S", "pacman", "-Sy", pkg.pkg_name]
         self._run_terminal(cmd, f"Reinstall {pkg.pkg_name}",
                            on_success=self._refresh_selected_pkg)
 
@@ -1599,7 +1619,9 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
-        out, code = run_command(f"pacman -Qi '{pkg.pkg_name}' 2>/dev/null")
+        if not is_safe_package_name(pkg.pkg_name):
+            return
+        out, code = run_command(["pacman", "-Qi", pkg.pkg_name])
         pkg.pkg_status = "installed" if (code == 0 and out) else "available"
         installed = pkg.pkg_status == "installed"
         self.btn_install.set_sensitive(not installed)
@@ -1635,8 +1657,7 @@ class pachubWindow(Adw.ApplicationWindow):
     def _get_aur_helper(self):
         if self._aur_helper_cache is None:
             for h in ("paru", "yay", "pikaur", "trizen"):
-                _, c = run_command(f"which {h} 2>/dev/null")
-                if c == 0:
+                if shutil.which(h):
                     self._aur_helper_cache = h
                     break
         return self._aur_helper_cache


### PR DESCRIPTION
Replace shell-based command execution for pacman and AUR lookups with argv-based subprocess calls to prevent command injection from search text, package names, and repository names.

Add validation helpers for package and repository identifiers, and apply them before package info, file lookup, install, remove, reinstall, and orphan-removal operations.

Update the PTY terminal runner to execute argv lists directly, constrain editor launching for pacman.conf edits, validate mirror country input, and quote the remaining fixed shell snippets used for mirrorlist and cache workflows.

Remove automatic --noconfirm usage from package-manager actions and installer dependency installation so privileged package changes require normal pacman confirmation.