### PR TITLE
fix: harden user-controlled package commands

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -13,6 +13,8 @@ Caching strategy
 
 import json
 import os
+import re
+import shutil
 import subprocess
 import threading
 import time
@@ -28,6 +30,7 @@ PKG_CACHE      = CACHE_DIR / "packages.json"
 SYNCDB_CACHE   = CACHE_DIR / "syncdb.json"
 INSTALLED_CACHE= CACHE_DIR / "installed.json"
 SYNCDB_TTL     = 6 * 3600   # 6 hours
+SAFE_PACKAGE_NAME_RE = re.compile(r"^[A-Za-z0-9._+@-]+$")
 
 def _ensure_cache_dir():
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -61,7 +64,13 @@ def _file_age(path):
 
 def run_command(cmd, timeout=30):
     try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        r = subprocess.run(
+            cmd,
+            shell=isinstance(cmd, str),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
         return r.stdout.strip(), r.returncode
     except subprocess.TimeoutExpired:
         return "", 1
@@ -74,7 +83,8 @@ def run_command_stream(cmd, on_line, on_done, timeout=180):
     def worker():
         try:
             proc = subprocess.Popen(
-                cmd, shell=True,
+                cmd,
+                shell=isinstance(cmd, str),
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
                 text=True, bufsize=1
@@ -90,8 +100,18 @@ def run_command_stream(cmd, on_line, on_done, timeout=180):
 
 
 def _is_demo():
-    _, code = run_command("which pacman 2>/dev/null")
-    return code != 0
+    return shutil.which("pacman") is None
+
+
+def is_safe_package_name(name):
+    return bool(name and SAFE_PACKAGE_NAME_RE.fullmatch(name))
+
+
+def find_installed_helper(*helpers):
+    for helper in helpers:
+        if shutil.which(helper):
+            return helper
+    return None
 
 
 # ─── Popular AUR packages to always show in the list ─────────────────────────
@@ -332,10 +352,12 @@ def invalidate_syncdb_cache():
 # ─── Package info / files ─────────────────────────────────────────────────────
 
 def get_package_info(pkg_name):
-    out, code = run_command(f"pacman -Qi '{pkg_name}' 2>/dev/null")
+    if not is_safe_package_name(pkg_name):
+        return "Invalid package name."
+    out, code = run_command(["pacman", "-Qi", pkg_name])
     if out and code == 0:
         return out
-    out2, code2 = run_command(f"pacman -Si --noconfirm '{pkg_name}' 2>/dev/null")
+    out2, code2 = run_command(["pacman", "-Si", "--noconfirm", pkg_name])
     if out2 and code2 == 0:
         return out2
     return (f"Name           : {pkg_name}\nVersion        : 1.0.0-1\n"
@@ -349,7 +371,9 @@ def get_package_info(pkg_name):
 
 
 def get_package_files(pkg_name):
-    out, code = run_command(f"pacman -Ql '{pkg_name}' 2>/dev/null")
+    if not is_safe_package_name(pkg_name):
+        return ["Invalid package name."]
+    out, code = run_command(["pacman", "-Ql", pkg_name])
     if out and code == 0:
         return out.splitlines()
     return [f"{pkg_name} /usr/bin/{pkg_name}", f"{pkg_name} /usr/share/man/man1/{pkg_name}.1"]
@@ -430,21 +454,16 @@ def search_packages_cmd(query):
     packages = []
     seen = set()
 
-    out, code = run_command(f"pacman -Ss '{query}' 2>/dev/null")
+    out, code = run_command(["pacman", "-Ss", query])
     if out and code == 0:
         for p in parse_pacman_ss(out):
             if p["name"] not in seen:
                 seen.add(p["name"])
                 packages.append(p)
 
-    aur_helper = None
-    for h in ("yay", "paru"):
-        _, c = run_command(f"which {h} 2>/dev/null")
-        if c == 0:
-            aur_helper = h
-            break
+    aur_helper = find_installed_helper("yay", "paru")
     if aur_helper:
-        aur_out, aur_code = run_command(f"{aur_helper} -Ss --aur '{query}' 2>/dev/null", timeout=30)
+        aur_out, aur_code = run_command([aur_helper, "-Ss", "--aur", query], timeout=30)
         if aur_out and aur_code == 0:
             for p in parse_pacman_ss(aur_out):
                 if p["name"] not in seen:

--- a/dialogs.py
+++ b/dialogs.py
@@ -13,6 +13,7 @@ import pty
 import re as _re
 import select
 import fcntl
+import shlex
 import termios
 import struct
 import threading
@@ -23,6 +24,18 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib, Pango
 
 from backend import run_command, get_orphans, get_system_info
+
+
+def _sanitize_country_entry(raw):
+    countries = []
+    for part in raw.split(","):
+        value = part.strip()
+        if not value:
+            continue
+        if not _re.fullmatch(r"[A-Za-z][A-Za-z .'-]{0,58}", value):
+            raise ValueError(f"Invalid country value: {value}")
+        countries.append(value)
+    return countries
 
 
 # ─── Terminal dialog ──────────────────────────────────────────────────────────
@@ -63,7 +76,8 @@ def run_terminal_dialog(parent, cmd, title, on_success=None, on_done_extra=None)
     hdr.pack_start(cancel_btn)
     tv.add_top_bar(hdr)
 
-    cmd_lbl = Gtk.Label(label=f"$ {cmd}")
+    command_text = shlex.join(cmd) if isinstance(cmd, (list, tuple)) else cmd
+    cmd_lbl = Gtk.Label(label=f"$ {command_text}")
     cmd_lbl.add_css_class("caption")
     cmd_lbl.add_css_class("dim-label")
     cmd_lbl.set_halign(Gtk.Align.START)
@@ -225,7 +239,7 @@ def run_terminal_dialog(parent, cmd, title, on_success=None, on_done_extra=None)
         wrapped = (
             f"printf '\\033[1m>>> {safe_title}\\033[0m\\n'; "
             f"echo; "
-            f"{cmd}; "
+            f"{command_text}; "
             f"_ec=$?; "
             f"exit $_ec"
         )
@@ -512,8 +526,12 @@ def show_mirror_rater(parent, run_terminal_fn):
             if top_n > 0:
                 global_flags.append(f"--top-mirrors={top_n}")
             if countries_raw:
-                first = countries_raw.split(",")[0].strip()
-                global_flags.append(f"--entry-country={first!r}")
+                try:
+                    first = _sanitize_country_entry(countries_raw)[0]
+                except ValueError:
+                    preview_lbl.set_label("Invalid country filter. Use letters, spaces, apostrophes, hyphens, or periods.")
+                    return
+                global_flags.append(f"--entry-country={shlex.quote(first)}")
 
             sub_flags = [f"--sort-mirrors-by={sort_key}", f"--max-delay={max_delay}"]
             gf = " ".join(global_flags)
@@ -558,8 +576,12 @@ def show_mirror_rater(parent, run_terminal_fn):
             if https_only: gflags.append("--protocol=https")
             if top_n > 0:  gflags.append(f"--top-mirrors={top_n}")
             if countries_raw:
-                first = countries_raw.split(",")[0].strip()
-                gflags.append(f"--entry-country={first!r}")
+                try:
+                    first = _sanitize_country_entry(countries_raw)[0]
+                except ValueError:
+                    preview_lbl.set_label("Invalid country filter. Use letters, spaces, apostrophes, hyphens, or periods.")
+                    return
+                gflags.append(f"--entry-country={shlex.quote(first)}")
             sflags = [f"--sort-mirrors-by={sort_key}", f"--max-delay={max_delay}"]
             preview_lbl.set_label(
                 f"rate-mirrors {' '.join(gflags)} arch {' '.join(sflags)} | sudo tee /etc/pacman.d/mirrorlist"
@@ -662,7 +684,7 @@ def show_orphan_finder(parent, run_terminal_fn):
             name = o["name"]
             rm_btn.connect("clicked", lambda *_, n=name: (
                 dialog.close(),
-                run_terminal_fn(f"sudo -S pacman -R --noconfirm {n}", f"Remove {n}")
+                run_terminal_fn(["sudo", "-S", "pacman", "-R", "--noconfirm", n], f"Remove {n}")
             ))
             row.add_suffix(rm_btn)
             listbox.append(row)
@@ -673,12 +695,11 @@ def show_orphan_finder(parent, run_terminal_fn):
         btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         btn_box.set_halign(Gtk.Align.CENTER)
         btn_box.set_margin_top(12); btn_box.set_margin_bottom(16)
-        names = " ".join(o["name"] for o in orphans)
         remove_all_btn = Gtk.Button(label=f"Remove All {len(orphans)} Orphans")
         remove_all_btn.add_css_class("destructive-action")
         remove_all_btn.connect("clicked", lambda *_: (
             dialog.close(),
-            run_terminal_fn(f"sudo -S pacman -Rns --noconfirm {names}", "Remove All Orphans")
+            run_terminal_fn(["sudo", "-S", "pacman", "-Rns", "--noconfirm", *(o["name"] for o in orphans)], "Remove All Orphans")
         ))
         btn_box.append(remove_all_btn)
         outer.append(btn_box)

--- a/window.py
+++ b/window.py
@@ -4,6 +4,7 @@ Main application window: sidebar, search page, package list, detail panel,
 filtering, and all action handlers.
 """
 
+import shutil
 import threading
 
 import gi
@@ -15,6 +16,7 @@ from backend import (
     get_packages, get_package_info, get_package_files,
     check_updates, search_packages_cmd, run_command,
     invalidate_cache, invalidate_syncdb_cache,
+    is_safe_package_name,
 )
 from models import PackageItem, PackageRow, NavRow, REPO_BADGE_CLASS, pkg_icon
 from dialogs import (
@@ -1554,12 +1556,14 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
+        if not is_safe_package_name(pkg.pkg_name):
+            return
         if pkg.pkg_foreign:
             helper = self._get_aur_helper()
-            cmd = f"{helper} -S --noconfirm {pkg.pkg_name}" if helper \
-                  else f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = [helper, "-S", "--noconfirm", pkg.pkg_name] if helper \
+                  else ["sudo", "-S", "pacman", "-Sy", "--noconfirm", pkg.pkg_name]
         else:
-            cmd = f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = ["sudo", "-S", "pacman", "-Sy", "--noconfirm", pkg.pkg_name]
         self._run_terminal(cmd, f"Install {pkg.pkg_name}",
                            on_success=self._refresh_selected_pkg)
 
@@ -1567,6 +1571,8 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
+        if not is_safe_package_name(pkg.pkg_name):
+            return
         d = Adw.AlertDialog()
         d.set_heading(f"Remove {pkg.pkg_name}?")
         d.set_body(f"This will remove {pkg.pkg_name} ({pkg.pkg_version}) from your system.")
@@ -1576,7 +1582,7 @@ class pachubWindow(Adw.ApplicationWindow):
         def on_resp(dlg, resp):
             if resp == "remove":
                 self._run_terminal(
-                    f"sudo -S pacman -R --noconfirm {pkg.pkg_name}",
+                    ["sudo", "-S", "pacman", "-R", "--noconfirm", pkg.pkg_name],
                     f"Remove {pkg.pkg_name}",
                     on_success=self._refresh_selected_pkg)
         d.connect("response", on_resp)
@@ -1586,12 +1592,14 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
+        if not is_safe_package_name(pkg.pkg_name):
+            return
         if pkg.pkg_foreign:
             helper = self._get_aur_helper()
-            cmd = f"{helper} -S --noconfirm {pkg.pkg_name}" if helper \
-                  else f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = [helper, "-S", "--noconfirm", pkg.pkg_name] if helper \
+                  else ["sudo", "-S", "pacman", "-Sy", "--noconfirm", pkg.pkg_name]
         else:
-            cmd = f"sudo -S pacman -Sy --noconfirm {pkg.pkg_name}"
+            cmd = ["sudo", "-S", "pacman", "-Sy", "--noconfirm", pkg.pkg_name]
         self._run_terminal(cmd, f"Reinstall {pkg.pkg_name}",
                            on_success=self._refresh_selected_pkg)
 
@@ -1599,7 +1607,10 @@ class pachubWindow(Adw.ApplicationWindow):
         if not self._selected_pkg:
             return
         pkg = self._selected_pkg
-        out, code = run_command(f"pacman -Qi '{pkg.pkg_name}' 2>/dev/null")
+        if not is_safe_package_name(pkg.pkg_name):
+            pkg.pkg_status = "available"
+            return
+        out, code = run_command(["pacman", "-Qi", pkg.pkg_name])
         pkg.pkg_status = "installed" if (code == 0 and out) else "available"
         installed = pkg.pkg_status == "installed"
         self.btn_install.set_sensitive(not installed)
@@ -1635,8 +1646,7 @@ class pachubWindow(Adw.ApplicationWindow):
     def _get_aur_helper(self):
         if self._aur_helper_cache is None:
             for h in ("paru", "yay", "pikaur", "trizen"):
-                _, c = run_command(f"which {h} 2>/dev/null")
-                if c == 0:
+                if shutil.which(h):
                     self._aur_helper_cache = h
                     break
         return self._aur_helper_cache


### PR DESCRIPTION
## Summary
- switch user-controlled package and search commands to safe subprocess argument lists
- validate package names before install/remove/reinstall/info/file operations
- safely shell-join terminal commands and sanitize the mirror country input used in `rate-mirrors`

## Why
Issue #14 identified several command-injection paths caused by `shell=True` plus user-controlled values being interpolated directly into shell strings. This patch keeps shell pipelines where the UI genuinely needs them, but removes shell interpretation from package/search inputs and hardens the remaining terminal-facing command construction.

## Validation
- `py -3 -m py_compile backend.py window.py dialogs.py app.py models.py styles.py`

Closes #14.
