### PR TITLE
feat: use AUR helper for upgrades

### DIFF
--- a/window.py
+++ b/window.py
@@ -1526,7 +1526,9 @@ class pachubWindow(Adw.ApplicationWindow):
             self._updates = []
             self.stat_updates._num.set_label("0")
             self._nav_rows["updates"].set_count(0)
-        self._run_terminal("sudo -S pacman -Syu --noconfirm", "System Upgrade", on_success=_after)
+        helper = self._get_aur_helper()
+        cmd = [helper, "-Syu", "--noconfirm"] if helper else ["sudo", "-S", "pacman", "-Syu", "--noconfirm"]
+        self._run_terminal(cmd, "System Upgrade", on_success=_after)
 
     def _on_clean_cache(self, *_):
         self._run_terminal(


### PR DESCRIPTION
## Summary
- route the system upgrade action through the detected AUR helper when one is installed
- keep the existing pacman fallback for systems without an AUR helper

## Why
Issue #10 asks for updates to run through the AUR helper so repo and AUR packages can be handled in one flow. Using the helper for `-Syu` also preserves helper-specific behavior such as Arch news handling.

## Validation
- `py -3 -m py_compile window.py backend.py dialogs.py app.py models.py styles.py`

Closes #10.
