### PR TITLE
build: add PKGBUILD and fix README entrypoint

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,71 @@
+pkgname=pachub
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Pacman and AUR front end built with GTK4 and libadwaita"
+arch=('any')
+url="https://github.com/mrks1469/PacHub"
+license=('GPL2')
+depends=('python' 'gtk4' 'libadwaita' 'python-gobject')
+optdepends=(
+  'yay: AUR helper support'
+  'paru: AUR helper support'
+)
+source=(
+  'app.py'
+  'backend.py'
+  'dialogs.py'
+  'models.py'
+  'styles.py'
+  'window.py'
+  'io.github.mrks1469.pachub.svg'
+  'LICENSE'
+)
+sha256sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP')
+
+package() {
+  local appdir="$pkgdir/usr/share/pachub"
+  local desktop="$pkgdir/usr/share/applications/io.github.mrks1469.pachub.desktop"
+  local launcher="$pkgdir/usr/bin/pachub"
+
+  install -d "$appdir" \
+             "$pkgdir/usr/bin" \
+             "$pkgdir/usr/share/applications" \
+             "$pkgdir/usr/share/icons/hicolor/scalable/apps" \
+             "$pkgdir/usr/share/licenses/$pkgname"
+
+  for file in app.py backend.py dialogs.py models.py styles.py window.py; do
+    install -m 644 "$srcdir/$file" "$appdir/$file"
+  done
+
+  cat > "$launcher" <<'EOF'
+#!/usr/bin/env bash
+export PYTHONPATH="/usr/share/pachub:${PYTHONPATH:-}"
+exec python3 /usr/share/pachub/app.py "$@"
+EOF
+  chmod 755 "$launcher"
+
+  cat > "$desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=PacHub
+GenericName=Package Manager
+Comment=A powerful Pacman/AUR front end
+Exec=/usr/bin/pachub
+Icon=io.github.mrks1469.pachub
+Categories=System;PackageManager;
+Keywords=pacman;aur;packages;arch;
+Terminal=false
+StartupWMClass=pachub
+EOF
+
+  install -m 644 "$srcdir/io.github.mrks1469.pachub.svg" \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/io.github.mrks1469.pachub.svg"
+  install -m 644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Optional (for AUR search and install):
 
 ## Installation
 
-Place all three files in the same directory, then run:
+Place the repository files in the same directory, then run:
 
 ```bash
 chmod +x install.sh
@@ -90,14 +90,27 @@ The installer will:
 **Files required alongside `install.sh`:**
 ```
 install.sh
-pachub.py
+app.py
+backend.py
+dialogs.py
+models.py
+styles.py
+window.py
 io.github.mrks1469.pachub.svg
+```
+
+### Build a local pacman package
+
+This repository now includes a `PKGBUILD`, so you can build and install PacHub with:
+
+```bash
+makepkg -si
 ```
 
 ### Running without installing
 
 ```bash
-python3 pachub.py
+python3 app.py
 ```
 
 ## Usage
@@ -119,9 +132,15 @@ pachub
 ## Project Structure
 
 ```
-pachub.py                        # Single-file application
-io.github.mrks1469.pachub.svg   # Application icon
+app.py                           # Application entry point
+backend.py                       # Package and system data helpers
+dialogs.py                       # Modal dialogs and terminal UI
+models.py                        # Package row and model types
+styles.py                        # Shared UI styling
+window.py                        # Main application window
+io.github.mrks1469.pachub.svg    # Application icon
 install.sh                       # Installer script
+PKGBUILD                         # Local pacman package definition
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- add a repo-local `PKGBUILD` so PacHub can be built and installed with `makepkg -si`
- fix the README entry-point references from `pachub.py` to `app.py`
- update the documented file list and project structure to match the real repository layout

## Why
Issue #13 asks for a native Arch packaging path and points out that the README still references the wrong entry point. This adds the `PKGBUILD` option described in the issue and fixes the README so the documented install/run flow matches the actual codebase.

## Validation
- `bash -n PKGBUILD`

`makepkg` is not installed on this machine, so I could not run a local package build here.

Closes #13.
